### PR TITLE
chore: use -a arg on open function for darwin

### DIFF
--- a/pkg/goax/app/app_darwin.go
+++ b/pkg/goax/app/app_darwin.go
@@ -8,6 +8,6 @@ import (
 )
 
 func osOpen(appPath string) error {
-	cmd := exec.Command("open", appPath)
+	cmd := exec.Command("open", "-a", appPath)
 	return cmd.Start()
 }


### PR DESCRIPTION
Fix #20 